### PR TITLE
[Review History] Fixes issue with 1* reviews not showing as red

### DIFF
--- a/pageJs/profile/recordReviews.js
+++ b/pageJs/profile/recordReviews.js
@@ -157,8 +157,8 @@
         lat: review.lat,
         lng: review.lng
       };
-      const reviewPoints = review.review || { quality: 0 };
-      const quality = (review.review && review.review.quality) ? review.review.quality : 0;
+
+      const quality = (review.review && review.review.quality !== undefined) ? (review.review.quality || 1) : 0;
       const marker = new google.maps.Marker({
         map: gmap,
         position: latLng,

--- a/pageJs/profile/recordReviews.js
+++ b/pageJs/profile/recordReviews.js
@@ -158,7 +158,10 @@
         lng: review.lng
       };
 
-      const quality = (review.review && review.review.quality !== undefined) ? (review.review.quality || 1) : 0;
+      const isSkipped = review.review === 'skipped';
+      const isPending = review.review === false;
+      const hasReview = Boolean(review.review);
+      const quality = (hasReview && !isSkipped && !isPending) ? (review.review.quality || 1) : 0;
       const marker = new google.maps.Marker({
         map: gmap,
         position: latLng,


### PR DESCRIPTION
Rejects were supposed to be red, not grey as the pending/skipped. I missed this!

**Before**
<img width="254" alt="Screenshot 2020-03-21 at 10 30 23" src="https://user-images.githubusercontent.com/887163/77224814-2aa9eb00-6b61-11ea-8d46-1b751ed18c12.png">


**After**
<img width="186" alt="Screenshot 2020-03-21 at 10 31 07" src="https://user-images.githubusercontent.com/887163/77224815-2ed60880-6b61-11ea-8813-0eec8db1b95e.png">
