### PR TITLE
[fix] remove toLowerCase from links

### DIFF
--- a/pageJs/nominations/mapButtons.js
+++ b/pageJs/nominations/mapButtons.js
@@ -31,7 +31,6 @@ function updateCustomMaps(){
     	var link = customMaps[i].url;
 
     	//Link editing:
-    	link = link.toLowerCase();
     	link = link.replaceAll("%lat%", nomCtrl.currentNomination.lat);
     	link = link.replaceAll("%lng%", nomCtrl.currentNomination.lng);
     	link = link.replaceAll("%title%", nomCtrl.currentNomination.title);
@@ -73,5 +72,5 @@ document.addEventListener("WFPNomSelected", updateCustomMaps, false);
 //Needed entering variables into URLs
 String.prototype.replaceAll = function(search, replacement) {
     var target = this;
-    return target.replace(new RegExp(search, 'g'), replacement);
+    return target.replace(new RegExp(search, 'gi'), replacement);
 };

--- a/pageJs/review/mapButtons.js
+++ b/pageJs/review/mapButtons.js
@@ -25,7 +25,6 @@ function addMapDropdown(){
         var link = customMaps[i].url;
 
         //Link editing:
-        link = link.toLowerCase();
         link = link.replaceAll("%lat%", nSubCtrl.pageData.lat);
         link = link.replaceAll("%lng%", nSubCtrl.pageData.lng);
         link = link.replaceAll("%title%", nSubCtrl.pageData.title);
@@ -66,7 +65,7 @@ document.addEventListener("WFPNSubCtrlHooked", addMapDropdown);
 //Needed entering variables into URLs
 String.prototype.replaceAll = function(search, replacement) {
     var target = this;
-    return target.replace(new RegExp(search, 'g'), replacement);
+    return target.replace(new RegExp(search, 'gi'), replacement);
 };
 
 //NON-SECURE (But good enough for uniqueID on URLs)


### PR DESCRIPTION
Doing a toLowerCase was breaking the "Open In" functionality when the URL had uppercase letters in it.

This PR removes the need for that and adds a case insensitive flag to the replace method. Both in `pageJs/nominations/mapButtons.js` and `pageJs/review/mapButtons.js`.

This fix also allows to leverage the "Open In" functionality to, among others, open the Wayfarer Abuse form pre-filled directly with a custom map link in the format below:

Report Title/Description Edit:
`https://docs.google.com/forms/d/e/1FAIpQLSeXTFKKkhHmapgsLN7VuhKHkT7qWj9bJjH9I2UWPf2qwo20UQ/viewform?entry.1915069305=Title/Description%20Edit:%20Attempts%20to%20influence%20Reviewers&entry.1465131479=%title%&emailAddress=EMAILADDRESS&entry.1341794294=%lat%,%lng%&entry.1323647271=Trying%20to%20influence%20moving%20Wayspot%20into%20incorrect%20location`

