### PR TITLE
Fix nomination notifications appearing underneath content

### DIFF
--- a/assets/nominations.css
+++ b/assets/nominations.css
@@ -167,6 +167,7 @@ th, td{
   bottom: 1em;
   right: 1em;
   width: 30em;
+  z-index: 100;
 }
 
 .wfpNotification{


### PR DESCRIPTION
This issue resolves an issue where notifications on the nominations page appearing underneath the content of nominations.

This PR fixes #140 

<img width="486" alt="Screen Shot 2020-04-13 at 10 25 42 PM" src="https://user-images.githubusercontent.com/15164473/79179505-c08a0c00-7dd5-11ea-9905-d846ecaffc7d.png">
