### PR TITLE
Include wayfarer.nianticlabs.com/new/* in matching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://wayfarer.nianticlabs.com/*"],
+      "matches": ["*://wayfarer.nianticlabs.com/*","*://wayfarer.nianticlabs.com/new/*"],
       "js": ["js/mods/nominations.js", "js/mods/review.js", "js/mods/profile.js", "js/mods/header.js", "js/mods/all.js", "settings/settingsManager.js","main.js"],
       "run_at": "document_start"
     }


### PR DESCRIPTION
Plugin recently stopped working for me because pages now forward to *://wayfarer.nianticlabs.com/new/* - I believe this will fix it